### PR TITLE
Added install target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ include */include.mk
 
 all: solib examples tests docs docs_latex bugs_html AUTHORS
 
+install:
+	cp lib/libkoki.so /usr/lib/libkoki.so
+
 AUTHORS: tools/generate_authors
 	tools/generate_authors AUTHORS
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ On Ubuntu 11.10 and 11.04, these can be installed using:
 ~~~~~~~~~~~~~~~~
 (sudo) $ apt-get install gcc libcv-dev libhighgui-dev libcvaux-dev libyaml-dev freeglut3-dev
 ~~~~~~~~~~~~~~~~
+### Building and installing
+
+To build and install the libkoki library to the system you must run the
+following commands:
+
+~~~~~~~~~~~~~~~~
+$ make
+$ sudo make install
+~~~~~~~~~~~~~~~~
 
 ### Examples
 


### PR DESCRIPTION
The makefile didn't follow standard conventions and include an 'install' target.  I've added this to copy the compiled `libkoki.so` to `/usr/lib/libkoki.so`.  This way the library can be installed to the system without having to run `./shell` before being able to use the library.

Also I've modified the Readme to include instructions on how to install to the system.
